### PR TITLE
maxResults props added

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ If you use the hostedDomain param, make sure to validate the id_token (a JSON we
 |:------------:|:--------:|:------------------------------------:|:----------------:|
 |    clientId  |  string  |               REQUIRED               |                  |
 |    jsSrc     |  string  |                   -                  |                  |
+|  maxResults  |  number  |                  999                 |   By passing a number here you can restrict how many results you want to return   |
 | hostedDomain |  string  |                   -                  | URL of the Javascript file normally hosted by Google |
 | responseType |  string  |              permission              | Can be either space-delimited 'id_token', to retrieve an ID Token + 'permission' (or 'token'), to retrieve an Access Token, or 'code', to retrieve an Authorization Code.
 | accessType   |  string  |              online                  | Can be either 'online' or 'offline'. Use offline with responseType 'code' to retrieve a refresh token |

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,7 @@ export interface GoogleContactsProps {
   readonly disabledStyle?: CSSProperties;
   readonly type?: string;
   readonly accessType?: string;
+  readonly maxResults?: number;
   readonly render?: (props?: { onClick: () => void }) => JSX.Element;
 }
 

--- a/src/google-contacts.js
+++ b/src/google-contacts.js
@@ -11,7 +11,7 @@ import ButtonContent from './button-content'
 import { extractTitleFromEntry, extractEmailFromEntry, extractPhoneNumberFromEntry } from './utils'
 
 const SCOPE = 'https://www.googleapis.com/auth/contacts.readonly'
-const MAX_RESULTS = '999' // TODO Make this parametable or paginate
+// const MAX_RESULTS = '999' // TODO Make this parametable or paginate
 
 class GoogleContacts extends Component {
   constructor(props) {
@@ -52,7 +52,7 @@ class GoogleContacts extends Component {
         window.gapi.client
           .request({
             path: '/m8/feeds/contacts/default/full',
-            params: { 'max-results': MAX_RESULTS },
+            params: { 'max-results': this.props.maxResults },
             headers: {
               'GData-Version': '3.0',
               Authorization: `Bearer ${authResponse.access_token}`
@@ -251,7 +251,8 @@ GoogleContacts.propTypes = {
   accessType: PropTypes.string,
   render: PropTypes.func,
   theme: PropTypes.string,
-  icon: PropTypes.bool
+  icon: PropTypes.bool,
+  maxResults: PropTypes.number
 }
 
 GoogleContacts.defaultProps = {
@@ -263,6 +264,7 @@ GoogleContacts.defaultProps = {
   cookiePolicy: 'single_host_origin',
   uxMode: 'popup',
   disabled: false,
+  maxResults: 999,
   disabledStyle: {
     opacity: 0.6
   },


### PR DESCRIPTION
I was using this package for my project. One of our user has more that 2000 results. When the user is trying to get the contacts it was not full as the max results value was 999. So I added a props for it and also set the deafult to 999. Now if anyone give any maxResults then it will return accordingly if no value passed then the default value will be 999.